### PR TITLE
Adding support for loading from memory

### DIFF
--- a/audiotags.cpp
+++ b/audiotags.cpp
@@ -113,7 +113,7 @@ bool audiotags_write_properties(TagLib_FileRefRef *fileRefRef, unsigned int len,
   TagLib::Tag *t = fileRef->tag();
 
   bool prop_changed = false;
-  for(uint i = 0; i < len; i++) {
+  for(TagLib::uint i = 0; i < len; i++) {
     TagLib::String field(fields_c[i], TagLib::String::Type::UTF8);
     TagLib::String value(values_c[i], TagLib::String::Type::UTF8);
     if(field == "title") {

--- a/audiotags.go
+++ b/audiotags.go
@@ -57,6 +57,11 @@ func Open(filename string) (*File, error) {
 }
 
 func FromData(data []byte) (*File, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("got empty byte array")
+	}
+
+	// actually parse data
 	f := C.audiotags_file_memory((*C.char)(unsafe.Pointer(&data[0])), C.uint(len(data)))
 	if f == nil {
 		return nil, fmt.Errorf("cannot process provided data")
@@ -162,6 +167,10 @@ func (f *File) ReadAudioProperties() *AudioProperties {
 }
 
 func (f *File) WritePicture(data []byte, fmt, w, h int) bool {
+	if len(data) == 0 {
+		return false
+	}
+
 	if C.audiotags_write_picture((*C.TagLib_FileRefRef)(f), (*C.char)(unsafe.Pointer(&data[0])), C.uint(len(data)),
 			C.int(w), C.int(h), C.int(fmt)) {
 		return true

--- a/audiotags.h
+++ b/audiotags.h
@@ -29,18 +29,18 @@
 extern "C" {
 #endif
 
-typedef struct { int dummy; } TagLib_File;
+typedef struct { void *fileRef; void *ioStream; } TagLib_FileRefRef;
 typedef struct { int dummy; } TagLib_AudioProperties;
 
 extern void go_map_put(int id, char *key, char *val);
 
-void audiotags_free(void* pointer);
-TagLib_File *audiotags_file_new(const char *filename);
-void audiotags_file_close(TagLib_File *file);
-void audiotags_file_properties(const TagLib_File *file, int id);
-const TagLib_AudioProperties *audiotags_file_audioproperties(const TagLib_File *file);
-bool audiotags_write_property(TagLib_File *file, const char *field_c, const char *value_c);
-bool audiotags_write_properties(TagLib_File *file, unsigned int len, const char *fields_c[], const char *values_c[]);
+TagLib_FileRefRef *audiotags_file_new(const char *filename);
+TagLib_FileRefRef *audiotags_file_memory(const char *data, unsigned int length);
+void audiotags_file_close(TagLib_FileRefRef *file);
+void audiotags_file_properties(const TagLib_FileRefRef *file, int id);
+const TagLib_AudioProperties *audiotags_file_audioproperties(const TagLib_FileRefRef *file);
+bool audiotags_write_property(TagLib_FileRefRef *file, const char *field_c, const char *value_c);
+bool audiotags_write_properties(TagLib_FileRefRef *file, unsigned int len, const char *fields_c[], const char *values_c[]);
 
 int audiotags_audioproperties_length(const TagLib_AudioProperties *audioProperties);
 int audiotags_audioproperties_length_ms(const TagLib_AudioProperties *audioProperties);
@@ -48,8 +48,8 @@ int audiotags_audioproperties_bitrate(const TagLib_AudioProperties *audioPropert
 int audiotags_audioproperties_samplerate(const TagLib_AudioProperties *audioProperties);
 int audiotags_audioproperties_channels(const TagLib_AudioProperties *audioProperties);
 
-bool audiotags_write_picture(TagLib_File *file, const char *data, unsigned int length, int w, int h, int type);
-bool audiotags_remove_pictures(TagLib_File *file);
+bool audiotags_write_picture(TagLib_FileRefRef *file, const char *data, unsigned int length, int w, int h, int type);
+bool audiotags_remove_pictures(TagLib_FileRefRef *file);
 
 #ifdef __cplusplus
 }

--- a/audiotags.h
+++ b/audiotags.h
@@ -36,6 +36,7 @@ extern void go_map_put(int id, char *key, char *val);
 
 TagLib_FileRefRef *audiotags_file_new(const char *filename);
 TagLib_FileRefRef *audiotags_file_memory(const char *data, unsigned int length);
+TagLib_FileRefRef *audiotags_file_memory_with_name(const char *fileName, const char *data, unsigned int length);
 void audiotags_file_close(TagLib_FileRefRef *file);
 void audiotags_file_properties(const TagLib_FileRefRef *file, int id);
 const TagLib_AudioProperties *audiotags_file_audioproperties(const TagLib_FileRefRef *file);


### PR DESCRIPTION
So far you needed to provide a file for parsing. The underlying taglib library also supports loading from memory, which is being added as functionality here.

This extension avoids needing to store a file on disk for analysis (e.g. after downloading it from the network).